### PR TITLE
T275297: Added property name for 'wikivoyageTitle'

### DIFF
--- a/mediawiki-config/LocalSettings.php
+++ b/mediawiki-config/LocalSettings.php
@@ -298,6 +298,7 @@ $wgRecordWizardConfig['properties']['qualifier'] = 'P18';
 $wgRecordWizardConfig['properties']['wikipediaTitle'] = 'P19';
 $wgRecordWizardConfig['properties']['wiktionaryEntry'] = 'P20';
 $wgRecordWizardConfig['properties']['mediaType'] = 'P24';
+$wgRecordWizardConfig['properties']['wikivoyageTitle'] = 'P25';
 
 $wgRecordWizardConfig['items']['genderMale'] = 'Q16';
 $wgRecordWizardConfig['items']['genderFemale'] = 'Q17';


### PR DESCRIPTION
Implements https://phabricator.wikimedia.org/T275297 and relates to https://github.com/lingua-libre/RecordWizard/pull/6

This introduces the P25 property created for T275297, in MediaWiki's config.

**WARNING:** https://github.com/lingua-libre/RecordWizard/pull/6 must be merged first. This PR will remain as a draft until https://github.com/lingua-libre/RecordWizard/pull/6 no longer is.